### PR TITLE
Fix checking a symbol is a number

### DIFF
--- a/src/phoneNumber.tsx
+++ b/src/phoneNumber.tsx
@@ -48,7 +48,7 @@ class PhoneNumber {
 
     // eslint-disable-next-line class-methods-use-this
     isNumeric(n) {
-        return !Number.isNaN(parseFloat(n)) && Number.isFinite(n);
+        return !Number.isNaN(parseFloat(n)) && isFinite(n);
     }
 
     getCountryCodeOfNumber(number) {


### PR DESCRIPTION
```
Number.isFinite() is different from the global isFinite() function. The global isFinite() function converts the tested value to a Number, then tests it.

Number.isFinite() does not convert the values to a Number, and will not return true for any value that is not of the type Number.
```

Well, it turns out, the library never really worked.

```
const is = (n) => !Number.isNaN(parseFloat(n)) && Number.isFinite(n);

is(1)
true

is('1')
false

is('1.0')
false
```

```
n='1'; console.log('Number.isFinite', Number.isFinite(n), 'isFinite', isFinite(n))
Number.isFinite false isFinite true
```