### PR TITLE
Lets user edit the country code of the phone number via backspace fro…

### DIFF
--- a/src/PhoneInput.tsx
+++ b/src/PhoneInput.tsx
@@ -173,7 +173,18 @@ export default class PhoneInput<TextComponentType extends React.ComponentType = 
             : this.possiblyEliminateZeroAfterCountryCode(modifiedNumber);
         const iso2: string = PhoneNumber.getCountryCodeOfNumber(modifiedNumber);
 
-        const displayValue = this.format(modifiedNumber);
+        let countryDialCode
+        if (iso2){
+            const countryData = PhoneNumber.getCountryDataByCode(iso2)
+            countryDialCode = countryData.dialCode
+        }
+
+        let displayValue
+        if (modifiedNumber === `+${countryDialCode}`){
+            displayValue = modifiedNumber
+        } else {
+            displayValue = this.format(modifiedNumber);
+        }
 
         this.setState({
             iso2,


### PR DESCRIPTION
…m within the text input when autoformat is enabled

- Currently, if a user has entered a non US country code, they cannot use the backspace button to edit the country code because the auto format automatically adds a space to the end of the country code. This change removes the space from the end of the country code when only the country code is present in the input. 