### PR TITLE
Add Accessibility Label to PhoneInput

### DIFF
--- a/src/PhoneInput.tsx
+++ b/src/PhoneInput.tsx
@@ -27,7 +27,7 @@ export default class PhoneInput<TextComponentType extends React.ComponentType = 
         } = this.props;
 
         const {
-            countriesList, disabled,
+            countriesList, disabled
         } = this.props;
 
         if (countriesList) {
@@ -205,6 +205,10 @@ export default class PhoneInput<TextComponentType extends React.ComponentType = 
             : number;
     }
 
+    getAccessibilityLabel() {
+        return this.props.accessibilityLabel || 'Telephone input';
+    }
+
     focus() {
         this.inputPhone.focus();
     }
@@ -236,6 +240,7 @@ export default class PhoneInput<TextComponentType extends React.ComponentType = 
                         ref={(ref) => {
                             this.inputPhone = ref;
                         }}
+                        accessibilityLabel={this.getAccessibilityLabel()}
                         editable={!disabled}
                         autoCorrect={false}
                         style={[styles.text, this.props.textStyle]}

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -55,6 +55,10 @@ export interface ReactNativeCountryPickerState {
 
 export interface ReactNativePhoneInputProps<TextComponentType extends React.ComponentType = typeof TextInput> {
     /**
+     * Override accessibility label for telephone input
+     */
+    accessibilityLabel?: string;
+    /**
      * Format input while typing
      */
     autoFormat?: boolean;


### PR DESCRIPTION
I needed to optionally pass through a custom accessibility label to this input, and so extended this component to allow that, while at the same time giving it something useful even if nothing gets passed