### PR TITLE
Fix missing typescript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "url": "https://github.com/rili-live/react-native-phone-input/issues"
   },
   "homepage": "https://github.com/rili-live/react-native-phone-input",
-  "types": "./typings/index.d.ts",
+  "types": "dist/typings/index.d.ts",
   "files": [
     "dist/"
   ]


### PR DESCRIPTION
Since `files` in package.json state that only `dist` folder is distributed, there is no `typings` folder in installed package, so typescript typings are not working