### PR TITLE
Fix: types of renderFlag function extended

### DIFF
--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -161,7 +161,7 @@ export interface ReactNativePhoneInputProps<TextComponentType extends React.Comp
     /**
      * Render function to replace the default flag
      */
-    renderFlag?: ({ imageSource }: { imageSource: number }) => Element;
+    renderFlag?: ({ imageSource }: { imageSource: number }) => Element | JSX.Element;
 }
 
 export default class ReactNativePhoneInput<


### PR DESCRIPTION
### Description
Type for `renderFlag` function extended to make available to place any JSX.Element and render it on flag place. 
### Motivation
I want to use this lib in FC way with external library (`react-native-country-picker-modal`) with both auto-detect country by calling code feature and set calling code on country select with modal feature

I've tested, it works fine.

But without this PR i have to deal with type error that says that `Type '({ imageSource }: { imageSource: number; }) => JSX.Element' is not assignable to type '({ imageSource }: { imageSource: number; }) => Element'.`

`CountryPicker` in provided example is exported from `react-native-country-picker-modal 2.0.0`. It's JSX.Element

![image](https://github.com/rili-live/react-native-phone-input/assets/69750825/5771ba87-9c44-40d0-ab17-b32eebd42712)
![image](https://github.com/rili-live/react-native-phone-input/assets/69750825/72c9d0cf-a4c8-4a8a-90ea-419f1effffd6)

### Additional info
Rendering CountryPicker as children is also not allowed (even though Readme file says it). If you'll accept this PR i'm going to update Readme file too and add to documentation new clean and actual example with external library usage like  `react-native-country-picker-modal` in FC way.

![image](https://github.com/rili-live/react-native-phone-input/assets/69750825/ecf1d6e1-0c8b-4212-a4f6-18c8caa7e934)

Best regards
