### PR TITLE
Fix pickerItemStyle typing

### DIFF
--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -113,7 +113,7 @@ export interface ReactNativePhoneInputProps<TextComponentType extends React.Comp
     /**
      * Custom styles for text in country picker eg. {{fontSize: 14}}
      */
-    pickerItemStyle?: ViewStyle;
+    pickerItemStyle?: TextStyle;
     /**
      * Cancel word
      */


### PR DESCRIPTION
The prop `pickerItemStyle` is directly forwarded to the `Picker` as `itemStyle` prop [here](https://github.com/rili-live/react-native-phone-input/blob/da5c6a74ead01d4eb50f068af7cbe2865e7a72a7/src/PhoneInput.tsx#L277).
Regarding [the documentation](https://github.com/react-native-picker/picker#itemstyle) of `@react-native-picker/picker`, `itemStyle` should extend `TextStyle`.

It fixes our error:

<img width="747" alt="Screenshot 2024-10-16 at 12 12 23" src="https://github.com/user-attachments/assets/7cce02d2-f00a-4f4f-8e45-049e7fa19c27">
