### PR TITLE
fix: bugs, type definitions, and test coverage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,4 +40,12 @@ module.exports = {
             }
         ],
     },
+    overrides: [
+        {
+            files: ['tests/**/*.ts'],
+            rules: {
+                'no-unused-expressions': 'off',
+            },
+        },
+    ],
 };

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+## Project Overview
+
+React Native phone input component with international country picker, phone number validation, and formatting. Published to npm as `react-native-phone-input`.
+
+## Key Commands
+
+```bash
+npm test              # Run tests (mocha + chai + ts-node)
+npm run test-coverage # Run tests with nyc coverage report
+npm run build         # Clean dist/, copy flags, compile TypeScript
+npm run lint          # ESLint (airbnb-base + typescript + react)
+npm run lint-fix      # ESLint with auto-fix
+```
+
+## Architecture
+
+- **Class-based React components** — do not convert to hooks (breaking change risk)
+- **Singleton pattern** — `PhoneNumber`, `Country`, and `FlagResource` are exported as singleton instances
+- `Country.getAll()` caches on first call; `setCustomCountriesData()` must be called before first access
+- Phone validation/formatting uses `google-libphonenumber`
+- Country picker uses `@react-native-picker/picker` (peer dependency)
+
+## Source Structure
+
+```
+src/
+  index.tsx           # Entry point, re-exports all public modules
+  PhoneInput.tsx      # Main component (default export)
+  CountryPicker.tsx   # Modal country picker component
+  PhoneNumber.tsx     # Phone validation/formatting utility (singleton)
+  country.tsx         # Country data management (singleton)
+  styles.ts           # StyleSheet definitions
+  typings/index.d.ts  # Public TypeScript type definitions
+  resources/
+    countries.json    # 243 countries (name, iso2, dialCode, priority, areaCodes)
+    numberType.json   # Phone number type enum mapping
+    flags/            # Flag PNG images + index.ts loader
+```
+
+## Testing
+
+- Framework: mocha + chai, run via ts-node
+- Test files: `tests/*.test.ts`
+- Pre-commit hook runs lint, pre-push hook runs tests
+- Coverage thresholds are currently set to 0 (not enforced)
+
+## Build & Publish
+
+- `npm run build` compiles TypeScript and copies flag images to `dist/`
+- Only `dist/` is published to npm (see `files` in package.json)
+- `npm run prepare` runs build automatically on install/publish
+- Type definitions are at `dist/typings/index.d.ts`
+
+## Style Guidelines
+
+- 4-space indentation
+- Max line length: 160 characters
+- Comma-dangle: only-multiline
+- Use specific lodash imports (`import { find } from 'lodash'`), not default import

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ import PhoneInput from 'react-native-phone-input'
 
 render(){
     return(
-        <PhoneInput ref='phone'/>
+        <PhoneInput ref={(ref) => { this.phone = ref; }}/>
     )
 }
 ```
 
-[see full basic example](https://github.com/thegamenicorus/react-native-phone-input/blob/master/examples/BasicExample/app.js)
+[see full basic example](https://github.com/rili-live/react-native-phone-input/blob/master/examples/BasicExample/app.js)
 
 ## Using a Custom Country Picker
 (android/ios)
@@ -82,7 +82,7 @@ render(){
 }
 ```
 
-[see full custom picker example](https://github.com/thegamenicorus/react-native-phone-input/blob/master/examples/CustomPicker/app.js)
+[see full custom picker example](https://github.com/rili-live/react-native-phone-input/blob/master/examples/CustomPicker/app.js)
 
 ## Using a Custom (External) Library Picker
 
@@ -143,7 +143,7 @@ render(){
 }
 ```
 
-[see full custom library picker example](https://github.com/thegamenicorus/react-native-phone-input/blob/master/examples/CustomLibraryPicker/app.js)
+[see full custom library picker example](https://github.com/rili-live/react-native-phone-input/blob/master/examples/CustomLibraryPicker/app.js)
 
 ## Custom Flag component 
 
@@ -207,16 +207,14 @@ If you need to change how the flag is rendered, you can use the `renderFlag` pro
 | Function Name   | Return Type | Parameters  | Description                                       |
 | --------------- | ----------- | ----------- | ------------------------------------------------- |
 | isValidNumber   | boolean     | none        | return true if current phone number is valid      |
-| getNumberType   | string      | none        | return true type of current phone number          |
+| getNumberType   | string      | none        | return type of current phone number               |
 | getValue        | string      | none        | return current phone number (unformatted)         |
-| getFlag         | object      | iso2:string | return flag image                                 |
-| getAllCountries | object      | none        | return country object in country picker           |
-| getPickerData   | object      | nont        | return country object with flag image             |
+| getFlag         | image       | iso2:string | return flag image                                 |
+| getAllCountries  | array       | none        | return array of all country objects                |
+| getPickerData   | array       | none        | return array of country objects with flag images   |
 | focus           | void        | none        | focus the phone input                             |
 | blur            | void        | none        | blur the phone input                              |
 | selectCountry   | void        | iso2:string | set phone input to specific country               |
 | setValue        | void        | string      | set phone input value                             |
 | getCountryCode  | string      | none        | return country dial code of current phone number  |
 | getISOCode      | string      | none        | return country iso code of current phone number   |
-| onPressCancel   | func        | none        | handler to be called when taps the cancel button  |
-| onPressConfirm  | func        | none        | handler to be called when taps the confirm button |

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   ],
   "dependencies": {
     "google-libphonenumber": "^3.2.32",
-    "lodash": "^4.17.21",
-    "prop-types": "^15.8.1"
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
     "@react-native-picker/picker": ">= 2.0",

--- a/src/CountryPicker.tsx
+++ b/src/CountryPicker.tsx
@@ -11,8 +11,6 @@ import { ReactNativeCountryPickerProps, ReactNativeCountryPickerState } from './
 const PickerItem = Picker.Item;
 
 export default class CountryPicker extends Component<ReactNativeCountryPickerProps, ReactNativeCountryPickerState> {
-    private picker: any;
-
     constructor(props) {
         super(props);
 
@@ -66,7 +64,7 @@ export default class CountryPicker extends Component<ReactNativeCountryPickerPro
     }
 
     // eslint-disable-next-line class-methods-use-this
-    renderItem(country, index) {
+    renderItem(country) {
         return <PickerItem key={country.iso2} value={country.iso2} label={country.name} />;
     }
 
@@ -105,16 +103,13 @@ export default class CountryPicker extends Component<ReactNativeCountryPickerPro
 
                         <View style={styles.mainBox}>
                             <Picker
-                                ref={(ref) => {
-                                    this.picker = ref;
-                                }}
                                 style={styles.bottomPicker}
                                 selectedValue={this.state.selectedCountry}
                                 onValueChange={(country) => this.onValueChange(country)}
                                 itemStyle={itemStyle}
                                 mode="dialog"
                             >
-                                {Country.getAll().map((country, index) => this.renderItem(country, index))}
+                                {Country.getAll().map((country) => this.renderItem(country))}
                             </Picker>
                         </View>
                     </View>

--- a/src/CountryPicker.tsx
+++ b/src/CountryPicker.tsx
@@ -79,7 +79,7 @@ export default class CountryPicker extends Component<ReactNativeCountryPickerPro
                 transparent
                 visible={this.state.modalVisible}
                 onRequestClose={() => {
-                    console.log('Country picker has been closed.');
+                    this.onPressCancel();
                 }}
             >
                 <View style={styles.basicContainer}>

--- a/src/PhoneInput.tsx
+++ b/src/PhoneInput.tsx
@@ -27,7 +27,7 @@ export default class PhoneInput<TextComponentType extends React.ComponentType = 
         } = this.props;
 
         const {
-            countriesList, disabled
+            countriesList,
         } = this.props;
 
         if (countriesList) {
@@ -50,18 +50,10 @@ export default class PhoneInput<TextComponentType extends React.ComponentType = 
         }
 
         this.state = {
-            disabled,
             iso2: initialCountry,
             displayValue,
             value: initialValue,
         };
-    }
-
-    componentDidUpdate() {
-        const { disabled } = this.props;
-        if (disabled !== this.state.disabled) {
-            this.setState({ disabled }); // eslint-disable-line react/no-did-update-set-state
-        }
     }
 
     onChangePhoneNumber = (number) => {
@@ -176,7 +168,7 @@ export default class PhoneInput<TextComponentType extends React.ComponentType = 
         let countryDialCode;
         if (iso2) {
             const countryData = PhoneNumber.getCountryDataByCode(iso2);
-            countryDialCode = countryData.dialCode;
+            countryDialCode = countryData ? countryData.dialCode : undefined;
         }
 
         let displayValue;
@@ -201,7 +193,7 @@ export default class PhoneInput<TextComponentType extends React.ComponentType = 
     possiblyEliminateZeroAfterCountryCode(number) {
         const dialCode = PhoneNumber.getDialCode(number);
         return number.startsWith(`${dialCode}0`)
-            ? dialCode + number.substr(dialCode.length + 1)
+            ? dialCode + number.substring(dialCode.length + 1)
             : number;
     }
 
@@ -218,7 +210,8 @@ export default class PhoneInput<TextComponentType extends React.ComponentType = 
     }
 
     render() {
-        const { iso2, displayValue, disabled } = this.state;
+        const { iso2, displayValue } = this.state;
+        const { disabled } = this.props;
         const country = this.getAllCountries().find((c) => c.iso2 === iso2);
         const TextComponent: any = this.props.textComponent || TextInput;
         return (

--- a/src/PhoneNumber.tsx
+++ b/src/PhoneNumber.tsx
@@ -29,7 +29,7 @@ class PhoneNumber {
                     // if (this.countryCodes[numericChars]) {
                     if (Country.getCountryCodes()[numericChars]) {
                         // store the actual raw string (useful for matching later)
-                        dialCode = number.substr(0, i + 1);
+                        dialCode = number.substring(0, i + 1);
                     }
                     // longest dial code is 4 chars
                     if (numericChars.length === 4) {
@@ -69,7 +69,6 @@ class PhoneNumber {
         try {
             return phoneUtil.parse(number, iso2);
         } catch (err: any) {
-            console.log(`Exception was thrown: ${err.toString()}`);
             return null;
         }
     }

--- a/src/PhoneNumber.tsx
+++ b/src/PhoneNumber.tsx
@@ -1,9 +1,8 @@
-import _ from 'lodash';
+import { first, findKey } from 'lodash';
 import libPhoneNumber from 'google-libphonenumber';
 
 import Country from './country';
-import countries from './resources/countries.json'; // eslint-disable-line @typescript-eslint/no-unused-vars
-import numberType from './resources/numberType.json'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import numberType from './resources/numberType.json';
 
 const phoneUtil = libPhoneNumber.PhoneNumberUtil.getInstance();
 const asYouTypeFormatter = libPhoneNumber.AsYouTypeFormatter;
@@ -58,7 +57,7 @@ class PhoneNumber {
 
         // countryCode[0] can be null -> get first element that is not null
         if (countryCode) {
-            return _.first(countryCode.filter((iso2: any) => iso2));
+            return first(countryCode.filter((iso2: any) => iso2));
         }
 
         return '';
@@ -103,7 +102,7 @@ class PhoneNumber {
     getNumberType(number, iso2) {
         const phoneInfo = this.parse(number, iso2);
         const typeIndex = phoneInfo ? phoneUtil.getNumberType(phoneInfo) : -1;
-        return _.findKey(numberType, (noType) => noType === typeIndex);
+        return findKey(numberType, (noType) => noType === typeIndex);
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/src/country.tsx
+++ b/src/country.tsx
@@ -22,7 +22,7 @@ class Country {
             this.countryCodes[dialCode] = [];
         }
 
-        const index = priority || 0;
+        const index = priority ?? 0;
         this.countryCodes[dialCode][index] = iso2;
     }
 

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -1,8 +1,5 @@
-// Type definitions for react-native-phone-input 0.2
-// Project: https://github.com/thegamenicorus/react-native-phone-input
-// Definitions by: Matthew Elphick <https://github.com/maael>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// Type definitions for react-native-phone-input
+// Project: https://github.com/rili-live/react-native-phone-input
 
 import * as React from 'react'; // eslint-disable-line import/no-extraneous-dependencies
 import {
@@ -161,7 +158,7 @@ export interface ReactNativePhoneInputProps<TextComponentType extends React.Comp
     /**
      * Render function to replace the default flag
      */
-    renderFlag?: ({ imageSource }: { imageSource: number }) => Element | JSX.Element;
+    renderFlag?: ({ imageSource }: { imageSource: ImageRequireSource }) => React.ReactElement;
 }
 
 export default class ReactNativePhoneInput<

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -36,7 +36,7 @@ export interface PickerData {
 export interface ReactNativeCountryPickerProps {
     buttonColor?: string;
     cancelText?: string;
-    cancelTextStyle: TextStyle;
+    cancelTextStyle?: TextStyle;
     confirmText?: string;
     confirmTextStyle?: TextStyle;
     selectedCountry?: any;
@@ -192,12 +192,12 @@ export default class ReactNativePhoneInput<
     /**
     * Return country object in country picker
     */
-    getAllCountries: () => CountriesListItem;
+    getAllCountries: () => CountriesListItem[];
 
     /**
     * Return country object with flag image
     */
-    getPickerData: () => PickerData;
+    getPickerData: () => PickerData[];
 
     /**
     * Focus the phone input

--- a/tests/Country.test.ts
+++ b/tests/Country.test.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import Country from '../src/country';
+
+describe('Country', () => {
+    describe('getAll', () => {
+        it('returns a non-empty array', () => {
+            const countries = Country.getAll();
+            expect(countries).to.be.an('array');
+            expect(countries.length).to.be.greaterThan(0);
+        });
+
+        it('returns countries sorted by name', () => {
+            const countries = Country.getAll();
+            for (let i = 1; i < countries.length; i++) {
+                const current = countries[i].name.toLowerCase();
+                const previous = countries[i - 1].name.toLowerCase();
+                expect(current >= previous).to.equal(true,
+                    `Expected "${countries[i].name}" to come after "${countries[i - 1].name}"`);
+            }
+        });
+
+        it('each element has required properties', () => {
+            const countries = Country.getAll();
+            countries.forEach((country) => {
+                expect(country).to.have.property('name').that.is.a('string');
+                expect(country).to.have.property('iso2').that.is.a('string');
+                expect(country).to.have.property('dialCode').that.is.a('string');
+            });
+        });
+    });
+
+    describe('getCountryCodes', () => {
+        it('contains known dial codes', () => {
+            const codes = Country.getCountryCodes();
+            expect(codes['1']).to.be.an('array');
+            expect(codes['44']).to.be.an('array');
+        });
+
+        it('maps US dial code 1 to include us', () => {
+            const codes = Country.getCountryCodes();
+            expect(codes['1']).to.include('us');
+        });
+
+        it('maps GB dial code 44 to include gb', () => {
+            const codes = Country.getCountryCodes();
+            expect(codes['44']).to.include('gb');
+        });
+    });
+
+    describe('getCountryDataByCode', () => {
+        it('returns correct country for us', () => {
+            const us = Country.getCountryDataByCode('us');
+            expect(us).to.not.be.undefined;
+            expect(us.name).to.include('United States');
+            expect(us.dialCode).to.equal('1');
+        });
+
+        it('returns correct country for gb', () => {
+            const gb = Country.getCountryDataByCode('gb');
+            expect(gb).to.not.be.undefined;
+            expect(gb.dialCode).to.equal('44');
+        });
+
+        it('returns undefined for non-existent iso2 code', () => {
+            const result = Country.getCountryDataByCode('zz');
+            expect(result).to.be.undefined;
+        });
+
+        it('returns undefined for empty string', () => {
+            const result = Country.getCountryDataByCode('');
+            expect(result).to.be.undefined;
+        });
+    });
+});

--- a/tests/PhoneNumber.test.ts
+++ b/tests/PhoneNumber.test.ts
@@ -23,3 +23,162 @@ describe('getNumberType', () => {
         expect(numberType).to.equal('FIXED_LINE');
     });
 });
+
+describe('getDialCode', () => {
+    it('returns dial code for a valid international number', () => {
+        expect(PhoneNumber.getDialCode('+447900000001')).to.equal('+44');
+    });
+
+    it('returns dial code for US number', () => {
+        expect(PhoneNumber.getDialCode('+12025551234')).to.equal('+1');
+    });
+
+    it('returns empty string for numbers without + prefix', () => {
+        expect(PhoneNumber.getDialCode('447900000001')).to.equal('');
+    });
+
+    it('returns empty string for empty string input', () => {
+        expect(PhoneNumber.getDialCode('')).to.equal('');
+    });
+
+    it('handles numbers with formatting characters', () => {
+        expect(PhoneNumber.getDialCode('+44 7900 000001')).to.equal('+44');
+    });
+});
+
+describe('getNumeric', () => {
+    it('strips non-numeric characters from a string', () => {
+        expect(PhoneNumber.getNumeric('+44 7900-000(001)')).to.equal('447900000001');
+    });
+
+    it('returns empty string for all-alpha input', () => {
+        expect(PhoneNumber.getNumeric('abcdef')).to.equal('');
+    });
+
+    it('preserves digits only', () => {
+        expect(PhoneNumber.getNumeric('a1b2c3')).to.equal('123');
+    });
+});
+
+describe('isNumeric', () => {
+    it('returns true for numeric strings', () => {
+        expect(PhoneNumber.isNumeric('5')).to.equal(true);
+        expect(PhoneNumber.isNumeric('0')).to.equal(true);
+    });
+
+    it('returns false for non-numeric strings', () => {
+        expect(PhoneNumber.isNumeric('abc')).to.equal(false);
+        expect(PhoneNumber.isNumeric('+')).to.equal(false);
+    });
+});
+
+describe('getCountryCodeOfNumber', () => {
+    it('returns correct iso2 code for known numbers', () => {
+        expect(PhoneNumber.getCountryCodeOfNumber('+447900000001')).to.equal('gb');
+    });
+
+    it('returns us for US number', () => {
+        expect(PhoneNumber.getCountryCodeOfNumber('+12025551234')).to.equal('us');
+    });
+
+    it('returns empty string for invalid dial codes', () => {
+        expect(PhoneNumber.getCountryCodeOfNumber('+0001234')).to.equal('');
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(PhoneNumber.getCountryCodeOfNumber('')).to.equal('');
+    });
+});
+
+describe('isValidNumber', () => {
+    it('returns true for valid phone numbers', () => {
+        expect(PhoneNumber.isValidNumber('+442072212217', 'gb')).to.equal(true);
+    });
+
+    it('returns true for valid US number', () => {
+        expect(PhoneNumber.isValidNumber('+12025551234', 'us')).to.equal(true);
+    });
+
+    it('returns false for invalid phone numbers', () => {
+        expect(PhoneNumber.isValidNumber('+44000', 'gb')).to.equal(false);
+    });
+
+    it('returns false for empty input', () => {
+        expect(PhoneNumber.isValidNumber('', 'us')).to.equal(false);
+    });
+});
+
+describe('format', () => {
+    it('formats a US number correctly', () => {
+        const formatted = PhoneNumber.format('+12025551234', 'us');
+        expect(formatted).to.be.a('string');
+        expect(formatted).to.include('202');
+    });
+
+    it('formats a UK number correctly', () => {
+        const formatted = PhoneNumber.format('+442072212217', 'gb');
+        expect(formatted).to.be.a('string');
+        expect(formatted).to.include('20');
+    });
+
+    it('handles numbers with existing formatting', () => {
+        const formatted = PhoneNumber.format('+1 (202) 555-1234', 'us');
+        expect(formatted).to.be.a('string');
+        expect(formatted).to.include('202');
+    });
+});
+
+describe('parse', () => {
+    it('returns a phone number object for valid input', () => {
+        const result = PhoneNumber.parse('+442072212217', 'gb');
+        expect(result).to.not.be.null;
+    });
+
+    it('returns null for invalid input', () => {
+        const result = PhoneNumber.parse('invalid', 'gb');
+        expect(result).to.be.null;
+    });
+
+    it('returns null for empty string', () => {
+        const result = PhoneNumber.parse('', 'gb');
+        expect(result).to.be.null;
+    });
+});
+
+describe('getCountryDataByCode', () => {
+    it('returns country data for valid iso2', () => {
+        const us = PhoneNumber.getCountryDataByCode('us');
+        expect(us).to.not.be.undefined;
+        expect(us.name).to.be.a('string');
+        expect(us.dialCode).to.equal('1');
+        expect(us.iso2).to.equal('us');
+    });
+
+    it('returns country data for gb', () => {
+        const gb = PhoneNumber.getCountryDataByCode('gb');
+        expect(gb).to.not.be.undefined;
+        expect(gb.dialCode).to.equal('44');
+    });
+
+    it('returns undefined for invalid iso2', () => {
+        const result = PhoneNumber.getCountryDataByCode('zz');
+        expect(result).to.be.undefined;
+    });
+});
+
+describe('getAllCountries', () => {
+    it('returns a non-empty array', () => {
+        const countries = PhoneNumber.getAllCountries();
+        expect(countries).to.be.an('array');
+        expect(countries.length).to.be.greaterThan(0);
+    });
+
+    it('each element has required properties', () => {
+        const countries = PhoneNumber.getAllCountries();
+        countries.forEach((country) => {
+            expect(country).to.have.property('name');
+            expect(country).to.have.property('iso2');
+            expect(country).to.have.property('dialCode');
+        });
+    });
+});


### PR DESCRIPTION
- Fix null reference crash in PhoneInput.updateValue when countryData is undefined
- Fix Android back button not closing country picker modal (onRequestClose)
- Replace deprecated substr() with substring() in PhoneInput and PhoneNumber
- Remove componentDidUpdate anti-pattern; use props.disabled directly
- Use nullish coalescing (??) for priority in country.tsx
- Fix type definitions: cancelTextStyle optional, getAllCountries/getPickerData return arrays
- Remove unused prop-types dependency
- Remove console.log from production code in PhoneNumber.parse
- Add comprehensive tests for PhoneNumber and Country classes (3 → 42 tests)
- Add eslint override for no-unused-expressions in test files

https://claude.ai/code/session_015viBaeA5T6gX1bKKNty4hV